### PR TITLE
Accessory i hermetyzacja

### DIFF
--- a/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
@@ -7,6 +7,10 @@ public class DefaultCountingOutRhymer {
     private final int[] numbers = new int[MAX_STACK_CAPACITY];
     private int total = EMPTY_STACK_INDICATOR;
 
+    public int getTotal() {
+        return total;
+    }
+
     public void countIn(int in) {
         if (!isFull())
             numbers[++total] = in;

--- a/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
@@ -5,7 +5,7 @@ public class DefaultCountingOutRhymer {
     private static final int EMPTY_STACK_INDICATOR= -1;
     private static final int INVALID_STACK_VALUE = -1;
     private final int[] numbers = new int[MAX_STACK_CAPACITY];
-    public int total = EMPTY_STACK_INDICATOR;
+    private int total = EMPTY_STACK_INDICATOR;
 
     public void countIn(int in) {
         if (!isFull())

--- a/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery;
 
 public class FIFORhymer extends DefaultCountingOutRhymer {
 
-    public final DefaultCountingOutRhymer temp = new DefaultCountingOutRhymer();
+    private final DefaultCountingOutRhymer temp = new DefaultCountingOutRhymer();
 
     @Override
     public int countOut() {

--- a/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery;
 
 public class HanoiRhymer extends DefaultCountingOutRhymer {
 
-    int totalRejected = 0;
+    private int totalRejected = 0;
 
     public int reportRejected() {
         return totalRejected;

--- a/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
+++ b/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
@@ -3,15 +3,15 @@ package edu.kis.vh.nursery.list;
 public class IntLinkedList {
 
     private Node last;
-    int i;
+    private int i;
     private static final int INVALID_VALUE = -1;
     public void push(int i) {
         if (last == null)
             last = new Node(i);
         else {
-            last.next = new Node(i);
-            last.next.prev = last;
-            last = last.next;
+            last.setNext(new Node(i));
+            last.getNext().setPrev(last);
+            last = last.getNext();
         }
     }
 
@@ -26,15 +26,22 @@ public class IntLinkedList {
     public int top() {
         if (isEmpty())
             return INVALID_VALUE;
-        return last.value;
+        return last.getValue();
     }
 
     public int pop() {
         if (isEmpty())
             return INVALID_VALUE;
-        int ret = last.value;
-        last = last.prev;
+        int ret = last.getValue();
+        last = last.getPrev();
         return ret;
     }
 
+    public int getI() {
+        return i;
+    }
+
+    public void setI(int i) {
+        this.i = i;
+    }
 }

--- a/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
+++ b/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery.list;
 
 public class IntLinkedList {
 
-    Node last;
+    private Node last;
     int i;
     private static final int INVALID_VALUE = -1;
     public void push(int i) {

--- a/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
+++ b/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
@@ -41,7 +41,4 @@ public class IntLinkedList {
         return i;
     }
 
-    public void setI(int i) {
-        this.i = i;
-    }
 }

--- a/src/main/java/edu/kis/vh/nursery/list/Node.java
+++ b/src/main/java/edu/kis/vh/nursery/list/Node.java
@@ -2,8 +2,8 @@ package edu.kis.vh.nursery.list;
 
 public class Node {
 
-    public final int value;
-    public Node prev, next;
+    final int value;
+    Node prev, next;
 
     public Node(int i) {
         value = i;

--- a/src/main/java/edu/kis/vh/nursery/list/Node.java
+++ b/src/main/java/edu/kis/vh/nursery/list/Node.java
@@ -2,11 +2,31 @@ package edu.kis.vh.nursery.list;
 
 public class Node {
 
-    final int value;
-    Node prev, next;
+    private final int value;
+    private Node prev;
+    private Node next;
 
     public Node(int i) {
         value = i;
     }
 
+    public Node getNext() {
+        return next;
+    }
+
+    public void setNext(Node next) {
+        this.next = next;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public Node getPrev() {
+        return prev;
+    }
+
+    public void setPrev(Node prev) {
+        this.prev = prev;
+    }
 }

--- a/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
+++ b/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
@@ -7,27 +7,27 @@ class RhymersDemo {
     private static final int MAX_COUNT = 15;
     public static void main(String[] args) {
         Rhymersfactory factory = new DefaultRhymersFactory();
-        
+
         DefaultCountingOutRhymer[] rhymers = { factory.getStandardRhymer(), factory.getFalseRhymer(),
                 factory.getFIFORhymer(), factory.getHanoiRhymer()};
-        
+
         for (int i = 1; i < MAX_COUNT; i++)
             for (int j = 0; j < 3; j++)
                 rhymers[j].countIn(i);
-        
+
         java.util.Random rn = new java.util.Random();
         for (int i = 1; i < MAX_COUNT; i++)
             rhymers[3].countIn(rn.nextInt(20));
-        
+
         for (int i = 0; i < rhymers.length; i++) {
             while (!rhymers[i].callCheck())
                 System.out.print(rhymers[i].countOut() + "  ");
             System.out.println();
         }
-        
+
         System.out.println("total rejected is "
                 + ((HanoiRhymer) rhymers[3]).reportRejected());
-        
+
     }
-    
+
 }

--- a/src/test/java/edu/kis/vh/nursery/RhymersJUnitTest.java
+++ b/src/test/java/edu/kis/vh/nursery/RhymersJUnitTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 public class RhymersJUnitTest {
 
-    public static final int TEST_IN_VALUE = 888;
+    private static final int TEST_IN_VALUE = 888;
 
     @Test
     public void testCountIn() {


### PR DESCRIPTION
9. Przeanalizuj atrybuty klas pod kątem widoczności (modyfikatory public, private, etc. ). Zastosuj możliwie
najmniejszą widoczność.
10. Wygeneruj getter dla pola total w klasie DefaultCountingOutRhymer (opcja Source → Generate Getters and
Setters).
11. Dokonaj hermetyzacji nieprywatnych atrybutów (polecenie Refactor → Encapsulate Field, w eclipse użyte z
opcją keep field reference, w IntelliJ opcja Use accesors even when field is accessible powinna być
odznaczona).
12. Usuń nieużywane setter (np. w Eclipse do analizy wywołań możesz użyć opcji Navigate → Open Call Hierarchy
(ctrl+alt+h)).